### PR TITLE
Make downgrade options configurable

### DIFF
--- a/src/main/java/com/gdssecurity/handlers/BTPHttpResponseHandler.java
+++ b/src/main/java/com/gdssecurity/handlers/BTPHttpResponseHandler.java
@@ -24,6 +24,7 @@ import burp.api.montoya.proxy.http.ProxyResponseHandler;
 import burp.api.montoya.proxy.http.ProxyResponseReceivedAction;
 import burp.api.montoya.proxy.http.ProxyResponseToBeSentAction;
 import com.gdssecurity.helpers.BTPConstants;
+import com.gdssecurity.providers.BTPContextMenuItemsProvider;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -79,7 +80,49 @@ public class BTPHttpResponseHandler implements ProxyResponseHandler {
                     return ProxyResponseReceivedAction.continueWith(interceptedResponse);
                 } else {
                     body.remove("availableTransports");
-                    body.put("availableTransports", this.modifiedTransports);
+
+                    modifiedTransports = new JSONArray();
+                    boolean wsText = BTPContextMenuItemsProvider.getBoolean(_montoya, "WebSockets: Text", false);
+                    boolean wsBinary = BTPContextMenuItemsProvider.getBoolean(_montoya, "WebSockets: Binary", false);
+                    boolean ssText = BTPContextMenuItemsProvider.getBoolean(_montoya, "ServerSentEvents: Text", true);
+                    boolean lpText = BTPContextMenuItemsProvider.getBoolean(_montoya, "LongPolling: Text", true);
+                    boolean lpBinary = BTPContextMenuItemsProvider.getBoolean(_montoya, "LongPolling: Binary", true);
+
+                    if (wsText||wsBinary) {
+                        JSONObject ws = new JSONObject();
+                        ws.append("transport", "WebSockets");
+                        JSONArray formats = new JSONArray();
+                        if (wsText) {
+                            formats.put("Text");
+                        }
+                        if (wsBinary) {
+                            formats.put("Binary");
+                        }
+                        ws.put("transferFormats", formats);
+                        modifiedTransports.put(ws);
+                    }
+                    if (ssText) {
+                        JSONObject ss = new JSONObject();
+                        ss.append("transport", "ServerSentEvents");
+                        JSONArray formats = new JSONArray();
+                        formats.put("Text");
+                        ss.put("TransferFormats", formats);
+                        modifiedTransports.put(ss);
+                    }
+                    if (lpText||lpBinary) {
+                        JSONObject lp = new JSONObject();
+                        lp.append("transport", "LongPolling");
+                        JSONArray formats = new JSONArray();
+                        if (lpText) {
+                            formats.put("Text");
+                        }
+                        if (lpBinary) {
+                            formats.put("Binary");
+                        }
+                        lp.put("transferFormats", formats);
+                        modifiedTransports.put(lp);
+                    }
+                    body.put("availableTransports", modifiedTransports);
                     return ProxyResponseReceivedAction.continueWith(interceptedResponse.withBody(body.toString()));
                 }
             }

--- a/src/main/java/com/gdssecurity/providers/BTPContextMenuItemsProvider.java
+++ b/src/main/java/com/gdssecurity/providers/BTPContextMenuItemsProvider.java
@@ -26,6 +26,8 @@ import com.gdssecurity.helpers.BTPConstants;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -74,7 +76,54 @@ public class BTPContextMenuItemsProvider implements ContextMenuItemsProvider {
             this.sendSelectionToBTP(selection);
         });
         menuItems.add(sendToBTP);
+
+        ActionListener checkBoxListener = new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                JCheckBoxMenuItem selectedMenuItem = (JCheckBoxMenuItem) e.getSource();
+                String optionText = selectedMenuItem.getText();
+
+                _montoya.persistence().extensionData().setBoolean(optionText, selectedMenuItem.isSelected());
+
+                if (selectedMenuItem.isSelected()) {
+                    _logging.logToOutput(optionText + " is selected.");
+                } else {
+                    _logging.logToOutput(optionText + " is unselected.");
+                }
+            }
+        };
+
+        JMenu downGradeOptions = new JMenu();
+        downGradeOptions.setText("Downgrade Options");
+
+        JCheckBoxMenuItem webSocketsText = new JCheckBoxMenuItem("WebSockets: Text", getBoolean(_montoya,"WebSockets: Text", false));
+        webSocketsText.addActionListener(checkBoxListener);
+        downGradeOptions.add(webSocketsText);
+
+        JCheckBoxMenuItem webSocketsBinary = new JCheckBoxMenuItem("WebSockets: Binary", getBoolean(_montoya,"WebSockets: Binary", false));
+        webSocketsBinary.addActionListener(checkBoxListener);
+        downGradeOptions.add(webSocketsBinary);
+
+        JCheckBoxMenuItem serverSentEventsText = new JCheckBoxMenuItem("ServerSentEvents: Text", getBoolean(_montoya,"ServerSentEvents: Text", true));
+        serverSentEventsText.addActionListener(checkBoxListener);
+        downGradeOptions.add(serverSentEventsText);
+
+        JCheckBoxMenuItem longPollingText = new JCheckBoxMenuItem("LongPolling: Text", getBoolean(_montoya,"LongPolling: Text", true));
+        longPollingText.addActionListener(checkBoxListener);
+        downGradeOptions.add(longPollingText);
+
+        JCheckBoxMenuItem longPollingBinary = new JCheckBoxMenuItem("LongPolling: Binary", getBoolean(_montoya,"LongPolling: Binary", true));
+        longPollingBinary.addActionListener(checkBoxListener);
+        downGradeOptions.add(longPollingBinary);
+
+        menuItems.add(downGradeOptions);
+
         return menuItems;
+    }
+
+    public static boolean getBoolean(MontoyaApi montoya, String key, boolean defaultValue) {
+        Boolean returnValue = montoya.persistence().extensionData().getBoolean(key);
+        if (returnValue == null) return defaultValue;
+        return returnValue;
     }
 
     /**

--- a/src/main/java/com/gdssecurity/providers/BTPContextMenuItemsProvider.java
+++ b/src/main/java/com/gdssecurity/providers/BTPContextMenuItemsProvider.java
@@ -25,9 +25,13 @@ import com.gdssecurity.views.BTPView;
 import com.gdssecurity.helpers.BTPConstants;
 
 import javax.swing.*;
+import javax.swing.event.PopupMenuEvent;
+import javax.swing.event.PopupMenuListener;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -77,6 +81,28 @@ public class BTPContextMenuItemsProvider implements ContextMenuItemsProvider {
         });
         menuItems.add(sendToBTP);
 
+        JMenuItem downGradeOptions = new JMenuItem();
+        downGradeOptions.setText("Downgrade Options");
+        downGradeOptions.addActionListener(e -> {
+            showCheckBoxDialog();
+        });
+        menuItems.add(downGradeOptions);
+
+        return menuItems;
+    }
+
+    public void showCheckBoxDialog() {
+        // Create a new JDialog
+        JDialog dialog = new JDialog((JFrame) null, "Select Options", true);
+        dialog.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
+        dialog.setLayout(new BorderLayout());
+        dialog.setSize(300, 200);
+
+        // Create a panel to hold checkboxes
+        JPanel checkBoxPanel = new JPanel();
+        checkBoxPanel.setLayout(new BoxLayout(checkBoxPanel, BoxLayout.Y_AXIS));
+
+        //actionlistener for checkboxes
         ActionListener checkBoxListener = new ActionListener() {
             public void actionPerformed(ActionEvent e) {
                 JCheckBoxMenuItem selectedMenuItem = (JCheckBoxMenuItem) e.getSource();
@@ -92,32 +118,16 @@ public class BTPContextMenuItemsProvider implements ContextMenuItemsProvider {
             }
         };
 
-        JMenu downGradeOptions = new JMenu();
-        downGradeOptions.setText("Downgrade Options");
+        for (String option : List.of("WebSockets: Text", "WebSockets: Binary",
+                "ServerSentEvents: Text", "LongPolling: Text", "LongPolling: Binary")) {
+            JCheckBoxMenuItem checkBoxMenuItem = new JCheckBoxMenuItem(option, getBoolean(_montoya, option, false));
+            checkBoxMenuItem.addActionListener(checkBoxListener);
 
-        JCheckBoxMenuItem webSocketsText = new JCheckBoxMenuItem("WebSockets: Text", getBoolean(_montoya,"WebSockets: Text", false));
-        webSocketsText.addActionListener(checkBoxListener);
-        downGradeOptions.add(webSocketsText);
+            checkBoxPanel.add(checkBoxMenuItem);
+        }
 
-        JCheckBoxMenuItem webSocketsBinary = new JCheckBoxMenuItem("WebSockets: Binary", getBoolean(_montoya,"WebSockets: Binary", false));
-        webSocketsBinary.addActionListener(checkBoxListener);
-        downGradeOptions.add(webSocketsBinary);
-
-        JCheckBoxMenuItem serverSentEventsText = new JCheckBoxMenuItem("ServerSentEvents: Text", getBoolean(_montoya,"ServerSentEvents: Text", true));
-        serverSentEventsText.addActionListener(checkBoxListener);
-        downGradeOptions.add(serverSentEventsText);
-
-        JCheckBoxMenuItem longPollingText = new JCheckBoxMenuItem("LongPolling: Text", getBoolean(_montoya,"LongPolling: Text", true));
-        longPollingText.addActionListener(checkBoxListener);
-        downGradeOptions.add(longPollingText);
-
-        JCheckBoxMenuItem longPollingBinary = new JCheckBoxMenuItem("LongPolling: Binary", getBoolean(_montoya,"LongPolling: Binary", true));
-        longPollingBinary.addActionListener(checkBoxListener);
-        downGradeOptions.add(longPollingBinary);
-
-        menuItems.add(downGradeOptions);
-
-        return menuItems;
+        dialog.add(checkBoxPanel);
+        dialog.setVisible(true);
     }
 
     public static boolean getBoolean(MontoyaApi montoya, String key, boolean defaultValue) {


### PR DESCRIPTION
Adds a context menu that allows the user to select which transport options will be allowed when downgrading: 

![image](https://github.com/user-attachments/assets/094553b3-9d51-4de4-8748-5e4cb80880e9)

Updates the `availableTransports` based on the user's selections: 

```
"availableTransports":[{"transferFormats":["Text"],"transport":["WebSockets"]},{"transferFormats":["Text","Binary"],"transport":["LongPolling"]}]
```